### PR TITLE
Replace backticks with code tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ You should think of the `alternate` field as an implementation detail, but it po
 
 <dl>
   <dt>host component</dt>
-  <dd>The leaf nodes of a React application. They are specific to the rendering environment (e.g., in a browser app, they are `div`, `span`, etc.). In JSX, they are denoted using lowercase tag names.</dd>
+  <dd>The leaf nodes of a React application. They are specific to the rendering environment (e.g., in a browser app, they are <code>div</code>, <code>span</code>, etc.). In JSX, they are denoted using lowercase tag names.</dd>
 </dl>
 
 Conceptually, the output of a fiber is the return value of a function.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Before we dive into the new stuff, let's review a few concepts.
   <dd>The algorithm React uses to diff one tree with another to determine which parts need to be changed.</dd>
 
   <dt>update</dt>
-  <dd>A change in the data used to render a React app. Usually the result of `setState`. Eventually results in a re-render.</dd>
+  <dd>A change in the data used to render a React app. Usually the result of <code>setState</code>. Eventually results in a re-render.</dd>
 </dl>
 
 The central idea of React's API is to think of updates as if they cause the entire app to re-render. This allows the developer to reason declaratively, rather than worry about how to efficiently transition the app from any particular state to another (A to B, B to C, C to A, and so on).


### PR DESCRIPTION
Looks like GitHub markdown parser isn't able to understand the meaning of the backtick inside HTML. This replacement fixes it.

| before | after |
| ----- | ----- |
| ![selection_027](https://user-images.githubusercontent.com/5839225/31013040-1054096e-a536-11e7-9260-7982d9b259fc.png) | ![selection_026](https://user-images.githubusercontent.com/5839225/31013039-1053599c-a536-11e7-9707-d752e47af5f1.png) |



