### PR TITLE
Update fiber implementation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Please note that I am not on the React team, and do not speak from any authority
 
 This is also a work in progress. **Fiber is an ongoing project that will likely undergo significant refactors before it's completed.** Also ongoing are my attempts at documenting its design here. Improvements and suggestions are highly welcome.
 
-My goal is that after reading this document, you will understand Fiber well enough to [follow along as it's implemented](https://github.com/facebook/react/commits/master/src/renderers/shared/fiber), and eventually even be able to contribute back to React.
+My goal is that after reading this document, you will understand Fiber well enough to [follow along as it's implemented](https://github.com/facebook/react/blob/main/packages/react-reconciler/src/ReactFiber.new.js), and eventually even be able to contribute back to React.
 
 ### Prerequisites
 


### PR DESCRIPTION
I changed React fiber implementation code links since previous links were deprecated.